### PR TITLE
Fixes issue displaying setlists with no state.

### DIFF
--- a/app/poros/setlist_fm/search_response/event.rb
+++ b/app/poros/setlist_fm/search_response/event.rb
@@ -29,11 +29,13 @@ module SetlistFm
 
       def venue
         venue_json = response.fetch('venue')
+        city_info = venue_json.fetch('city')
+        country_info = city_info.fetch('country')
 
         Venue.new(
           venue_json.fetch('@name'),
-          venue_json.fetch('city').fetch('@name'),
-          venue_json.fetch('city').fetch('@state')
+          city_info.fetch('@name'),
+          city_info.fetch('@state', country_info.fetch('@name'))
         )
       end
 

--- a/app/poros/setlist_fm/search_response/event.rb
+++ b/app/poros/setlist_fm/search_response/event.rb
@@ -3,7 +3,6 @@ module SetlistFm
     class Event
       Artist = Struct.new(:name)
       Song = Struct.new(:title)
-      Venue = Struct.new(:name, :city, :state)
 
       def initialize(setlist_json_response)
         @response = setlist_json_response
@@ -28,15 +27,7 @@ module SetlistFm
       end
 
       def venue
-        venue_json = response.fetch('venue')
-        city_info = venue_json.fetch('city')
-        country_info = city_info.fetch('country')
-
-        Venue.new(
-          venue_json.fetch('@name'),
-          city_info.fetch('@name'),
-          city_info.fetch('@state', country_info.fetch('@name'))
-        )
+        Venue.new(response.fetch('venue'))
       end
 
       def url

--- a/app/poros/setlist_fm/search_response/event/venue.rb
+++ b/app/poros/setlist_fm/search_response/event/venue.rb
@@ -1,0 +1,49 @@
+module SetlistFm
+  class SearchResponse
+    class Event
+      class Venue
+        def initialize(venue_info_hash)
+          @venue_info_hash = venue_info_hash
+        end
+
+        def as_json(_options = {})
+          {
+            name: name,
+            city: city,
+            state: state
+          }
+        end
+
+        def name
+          venue_info_hash['@name']
+        end
+
+        def city
+          city_info['@name']
+        end
+
+        def state
+          city_info['@state'] || country
+        end
+
+        def country
+          country_info['@name']
+        end
+
+        private
+
+        attr_reader :venue_info_hash
+
+        def city_info
+          @city_info ||=
+            venue_info_hash['city'] || {}
+        end
+
+        def country_info
+          @country_info ||=
+            city_info['country'] || {}
+        end
+      end
+    end
+  end
+end

--- a/spec/poros/setlist_fm/search_response/event/venue_spec.rb
+++ b/spec/poros/setlist_fm/search_response/event/venue_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe SetlistFm::SearchResponse::Event::Venue do
+  describe '#name' do
+    it 'should use the @name attribute' do
+      venue_hash = { '@name' => 'venue name' }
+      venue = described_class.new(venue_hash)
+
+      expect(venue.name).to eq 'venue name'
+    end
+  end
+
+  describe '#city' do
+    it 'should use the @name value in the city hash' do
+      venue_hash = { 'city' => { '@name' => 'Westbury' } }
+      venue = described_class.new(venue_hash)
+
+      expect(venue.city).to eq 'Westbury'
+    end
+  end
+
+  describe '#state' do
+    context 'when the state name is avilable in the response hash' do
+      it "should use the city's state @name" do
+        venue_hash = { 'city' => { '@state' => 'New York' } }
+
+        venue = described_class.new(venue_hash)
+
+        expect(venue.state).to eq 'New York'
+      end
+
+      context 'when there is no state in the response hash' do
+        it 'should use the country' do
+          venue_hash = { 'city' => { 'country' => { '@name' => 'Greece' } } }
+          venue = described_class.new(venue_hash)
+
+          expect(venue.state).to eq 'Greece'
+        end
+      end
+    end
+  end
+
+  describe '#to_json' do
+    it 'should return the name, city, and state in a JSON format' do
+      venue_hash = {
+        '@name' => 'venue name',
+        'city' => {
+          '@name' => 'venue city',
+          '@state' => 'venue state'
+        }
+      }
+      event = described_class.new(venue_hash)
+      event_json = JSON.parse(event.to_json)
+
+      expect(event_json).to eq(
+        'name' => 'venue name',
+        'city' => 'venue city',
+        'state' => 'venue state'
+      )
+    end
+  end
+end

--- a/spec/poros/setlist_fm/search_response/event_spec.rb
+++ b/spec/poros/setlist_fm/search_response/event_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+Venue = SetlistFm::SearchResponse::Event::Venue
 
 describe SetlistFm::SearchResponse::Event do
   describe '#artist' do
@@ -70,67 +71,12 @@ describe SetlistFm::SearchResponse::Event do
   end
 
   describe '#venue' do
-    subject { described_class.new(response_with_venue) }
-    let(:response_with_venue) do
-      {
-        'venue' => {
-          '@id' => '53d483fd',
-          '@name' => 'The Space at Westbury',
-          'city' => {
-            '@id' => '5144040',
-            '@name' => 'Westbury',
-            '@state' => 'New York',
-            '@stateCode' => 'NY',
-            'coords' => {
-              '@lat' => '40.7556561',
-              '@long' => '-73.5876273'
-            },
-            'country' => {
-              '@code' => 'US',
-              '@name' => 'United States'
-            }
-          }
-        }
-      }
-    end
+    it 'create a Venue using the venue hash' do
+      response_with_venue = { 'venue' => { venue: :info } }
 
-    it 'should have a name' do
-      expect(subject.venue.name).to eq 'The Space at Westbury'
-    end
+      expect(Venue).to receive(:new).with(venue: :info)
 
-    it 'should have a city' do
-      expect(subject.venue.city).to eq 'Westbury'
-    end
-
-    it 'should have a state' do
-      expect(subject.venue.state).to eq 'New York'
-    end
-
-    context 'when the location has no state' do
-      it 'should use the country' do
-        response_with_no_state = {
-          'venue' => {
-            "@id"=>"3d619bb",
-            "@name"=>"Akti Dymaion",
-            "city"=> {
-              "@id"=>"255683",
-              "@name"=>"Patras",
-              "coords"=> {
-                "@lat"=>"38.2444444",
-                "@long"=>"21.7344444"
-              },
-              "country"=> {
-                "@code"=>"GR",
-                "@name"=>"Greece"
-              }
-            },
-            "url"=>"http://www.setlist.fm/venue/akti-dymaion-patras-greece-3d619bb.html"
-          }
-        }
-        event = described_class.new(response_with_no_state)
-
-        expect(event.venue.state).to eq 'Greece'
-      end
+      described_class.new(response_with_venue).venue
     end
   end
 

--- a/spec/poros/setlist_fm/search_response/event_spec.rb
+++ b/spec/poros/setlist_fm/search_response/event_spec.rb
@@ -105,6 +105,33 @@ describe SetlistFm::SearchResponse::Event do
     it 'should have a state' do
       expect(subject.venue.state).to eq 'New York'
     end
+
+    context 'when the location has no state' do
+      it 'should use the country' do
+        response_with_no_state = {
+          'venue' => {
+            "@id"=>"3d619bb",
+            "@name"=>"Akti Dymaion",
+            "city"=> {
+              "@id"=>"255683",
+              "@name"=>"Patras",
+              "coords"=> {
+                "@lat"=>"38.2444444",
+                "@long"=>"21.7344444"
+              },
+              "country"=> {
+                "@code"=>"GR",
+                "@name"=>"Greece"
+              }
+            },
+            "url"=>"http://www.setlist.fm/venue/akti-dymaion-patras-greece-3d619bb.html"
+          }
+        }
+        event = described_class.new(response_with_no_state)
+
+        expect(event.venue.state).to eq 'Greece'
+      end
+    end
   end
 
   describe '#url' do


### PR DESCRIPTION
There are some cases where the venue doesn't have a state (e.g.  non-American countries). Since `Event#venue` uses `fetch` to get values from the response hash and the response did not have the `@state` key this would raise a `KeyError`.

This changes the logic to return the country name if the state is not found.

We may want to consider not using fetch and retuning `nil`/empty strings rather than having the user end up stuck on a loading page.

I decided to also pull Event::Venue into its own class and drop the use of `fetch`.
